### PR TITLE
fix typos

### DIFF
--- a/pkg/argo/interpreter-command-tree.go
+++ b/pkg/argo/interpreter-command-tree.go
@@ -446,7 +446,7 @@ func (c *commandTreeInterpreter) interpretShortPair(element *parse.Element, unma
 		// Well let's see what we have to say about that.  It may be, if this is the
 		// last character in the block, that it has to have one anyway.
 		if !h {
-			c.tree.AppendWarning(fmt.Sprintf("flag -%c recieved an argument it didn't expect", b))
+			c.tree.AppendWarning(fmt.Sprintf("flag -%c received an argument it didn't expect", b))
 			return f.hitWithArg(element.Data[1])
 		}
 
@@ -555,7 +555,7 @@ func (c *commandTreeInterpreter) interpretLongPair(element *parse.Element, unmap
 		if flag.HasArgument() {
 			return flag.hitWithArg(element.Data[1])
 		} else {
-			c.tree.AppendWarning(fmt.Sprintf("flag --%s recieved an argument it didn't expect", element.Data[0]))
+			c.tree.AppendWarning(fmt.Sprintf("flag --%s received an argument it didn't expect", element.Data[0]))
 			return flag.hit()
 		}
 	}

--- a/pkg/argo/interpreter-command-tree_test.go
+++ b/pkg/argo/interpreter-command-tree_test.go
@@ -545,7 +545,7 @@ func TestTreeInterpretShortPair09(t *testing.T) {
 	} else if !flag.Argument().WasHit() {
 		t.Error("expected flag argument to have been hit but it wasn't")
 	} else if flag.Argument().RawValue() != "b=value" {
-		t.Error("expected flag argument to match input value but it doesn'")
+		t.Error("expected flag argument to match input value but it doesn't")
 	}
 }
 

--- a/pkg/argo/interpreter-command.go
+++ b/pkg/argo/interpreter-command.go
@@ -360,7 +360,7 @@ func (c *commandInterpreter) interpretShortPair(e *parse.Element) (bool, error) 
 		// Well let's see what we have to say about that.  It may be, if this is the
 		// last character in the block, that it has to have one anyway.
 		if !h {
-			c.command.AppendWarning(fmt.Sprintf("flag -%c recieved an argument it didn't expect", b))
+			c.command.AppendWarning(fmt.Sprintf("flag -%c received an argument it didn't expect", b))
 			return false, f.hitWithArg(e.Data[1])
 		}
 
@@ -467,7 +467,7 @@ func (c *commandInterpreter) interpretLongPair(e *parse.Element) (bool, error) {
 		if flag.HasArgument() {
 			return false, flag.hitWithArg(e.Data[1])
 		}
-		c.command.AppendWarning(fmt.Sprintf("flag --%s recieved an argument it didn't expect", e.Data[0]))
+		c.command.AppendWarning(fmt.Sprintf("flag --%s received an argument it didn't expect", e.Data[0]))
 		return false, flag.hit()
 	}
 


### PR DESCRIPTION
Found via `codespell -H -L fo,ot`